### PR TITLE
koonsplash-32 Move storage from Authorizer to KoonsplashAuthImpl

### DIFF
--- a/src/main/kotlin/pcf/crskdev/koonsplash/Main.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/Main.kt
@@ -11,6 +11,7 @@ import pcf.crskdev.koonsplash.auth.AuthToken
 import pcf.crskdev.koonsplash.auth.AuthTokenStorage
 import pcf.crskdev.koonsplash.auth.AuthenticityToken
 import pcf.crskdev.koonsplash.auth.AuthorizationCode
+import pcf.crskdev.koonsplash.auth.AuthorizeForm
 import pcf.crskdev.koonsplash.auth.AuthorizerImpl
 import pcf.crskdev.koonsplash.auth.InvalidCredentialsException
 import pcf.crskdev.koonsplash.auth.NeedsLoginException
@@ -56,6 +57,10 @@ object DummyAuthCalls : AuthCalls {
         redirectUri: URI,
         vararg scopes: AuthScope
     ): Result<AuthorizationCode> = Result.failure(NeedsLoginException("1234"))
+
+    override fun authorizeForm(authorizeForm: AuthorizeForm): Result<AuthorizationCode> {
+        TODO("Not yet implemented")
+    }
 
     override fun loginForm(
         authenticityToken: AuthenticityToken,

--- a/src/main/kotlin/pcf/crskdev/koonsplash/auth/AuthCalls.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/auth/AuthCalls.kt
@@ -45,6 +45,14 @@ interface AuthCalls {
     fun authorize(accessKey: AccessKey, redirectUri: URI, vararg scopes: AuthScope): Result<AuthorizationCode>
 
     /**
+     * Authorize form that should be submitted in case when scopes are other than _PUBLIC_
+     *
+     * @param authorizeForm AuthorizeForm
+     * @return AuthorizationCode
+     */
+    fun authorizeForm(authorizeForm: AuthorizeForm): Result<AuthorizationCode>
+
+    /**
      * Intermediary step login form.
      *
      * On successfully login, then one must use the _authorizeForm_ with _AuthenticityToken_ from result.

--- a/src/main/kotlin/pcf/crskdev/koonsplash/auth/AuthDefs.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/auth/AuthDefs.kt
@@ -32,6 +32,7 @@ typealias AccessKey = String
 typealias AuthorizationCode = String
 typealias AuthenticityToken = String
 typealias SecretKey = String
+typealias AuthorizeForm = List<Pair<String, String>>
 
 /**
  * Thrown when a login form is needed to continue the authorization process.
@@ -58,3 +59,18 @@ object GiveUpException : RuntimeException()
  *
  */
 object SignedOutException : RuntimeException()
+
+/**
+ * Thrown when sometimes after a successful login client must confirm the authorization config in
+ * order to get the AuthorizationCode.
+ *
+ * @property form AuthorizeForm
+ */
+class ConfirmAuthorizeException(val form: AuthorizeForm) : RuntimeException()
+
+/**
+ * Thrown when confirm authorize form was not successfully submitted.
+ *
+ * @property message Message
+ */
+class ConfirmAuthorizeFailureException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/pcf/crskdev/koonsplash/auth/LoginFormController.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/auth/LoginFormController.kt
@@ -40,13 +40,18 @@ abstract class LoginFormController {
     /**
      * Activate the login form (as in showing the ui form).
      *
+     * Is activated in two scenarios:
+     * - client is first time login, then _dueTo_ is null
+     * - there was a login error
+     *
+     * @param dueTo Throwable
      */
-    abstract fun activateForm()
+    abstract fun activateForm(dueTo: Throwable?)
 
     /**
      * Attach form.
      *
-     * @param loginFormListener
+     * @param loginFormListener LoginFormListener
      */
     fun attachFormListener(loginFormListener: LoginFormListener) {
         this.loginFormListener = loginFormListener
@@ -87,11 +92,12 @@ abstract class LoginFormController {
     /**
      * Give up on introducing credentials.
      *
+     * @param cause: Cause of giving up, may be null as in "unknown"
      */
-    fun giveUp() {
+    fun giveUp(cause: Throwable?) {
         requireNotNull(this.loginFormSubmitter)
-        this.loginFormListener?.onGiveUp()
-        this.loginFormSubmitter?.giveUp()
+        this.loginFormListener?.onGiveUp(cause)
+        this.loginFormSubmitter?.giveUp(cause)
         this.detachAll()
     }
 
@@ -109,9 +115,11 @@ abstract class LoginFormController {
      * On login failure.
      *
      * Note: is not called from main thread.
+     *
+     * @param cause Cause of failure.
      */
-    internal fun onLoginFailure() {
-        this.loginFormListener?.onFailure()
+    internal fun onLoginFailure(cause: Throwable) {
+        this.loginFormListener?.onFailure(cause)
     }
 
     /**

--- a/src/main/kotlin/pcf/crskdev/koonsplash/auth/LoginFormListener.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/auth/LoginFormListener.kt
@@ -38,12 +38,14 @@ interface LoginFormListener {
     /**
      * Called on login error.
      *
+     * @param cause: Cause of failure
      */
-    fun onFailure() { }
+    fun onFailure(cause: Throwable) { }
 
     /**
      * Called when user gives up on login in.
      *
+     * @param cause: Cause of giving up, may be null as in "unknown".
      */
-    fun onGiveUp() { }
+    fun onGiveUp(cause: Throwable?) { }
 }

--- a/src/main/kotlin/pcf/crskdev/koonsplash/auth/LoginFormSubmitter.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/auth/LoginFormSubmitter.kt
@@ -40,6 +40,8 @@ interface LoginFormSubmitter {
     /**
      * Give up submitting other credentials. This is internally called by LoginController.
      *
+     * @param cause cause of giving up, can be null as in "unknown"
+     *
      */
-    fun giveUp()
+    fun giveUp(cause: Throwable?)
 }

--- a/src/main/kotlin/pcf/crskdev/koonsplash/auth/OneShotLoginFormController.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/auth/OneShotLoginFormController.kt
@@ -43,11 +43,11 @@ internal class OneShotLoginFormController(
      */
     private val isSubmitted = AtomicBoolean(false)
 
-    override fun activateForm() {
+    override fun activateForm(dueTo: Throwable?) {
         if (isSubmitted.compareAndSet(false, true)) {
             this.submit(email, password)
         } else {
-            this.giveUp()
+            this.giveUp(dueTo)
         }
     }
 }

--- a/src/main/kotlin/pcf/crskdev/koonsplash/internal/KoonsplashImpl.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/internal/KoonsplashImpl.kt
@@ -65,6 +65,7 @@ class KoonsplashImpl(
                     controller,
                     { cont.resumeWithException(it) },
                     {
+                        storage.save(it)
                         cont.resume(
                             KoonsplashAuthImpl(it, accessKey, this@KoonsplashImpl, storage, httpClient)
                         )

--- a/src/test/kotlin/pcf/crskdev/koonsplash/auth/AuthorizerTest.kt
+++ b/src/test/kotlin/pcf/crskdev/koonsplash/auth/AuthorizerTest.kt
@@ -136,8 +136,8 @@ internal class AuthorizerImplTest : StringSpec({
         }
 
         verify(exactly = 1) {
-            loginForm.onFailure()
-            loginForm.onGiveUp()
+            loginForm.onFailure(any())
+            loginForm.onGiveUp(any())
             onFailure(any())
             server.stopServing()
         }
@@ -174,7 +174,7 @@ internal class AuthorizerImplTest : StringSpec({
         verify(exactly = 0) {
             onSuccess(any())
             loginForm.onSuccess()
-            loginForm.onFailure()
+            loginForm.onFailure(any())
         }
 
         verify {
@@ -213,7 +213,7 @@ internal class AuthorizerImplTest : StringSpec({
         verify(exactly = 0) {
             onSuccess(any())
             loginForm.onSuccess()
-            loginForm.onFailure()
+            loginForm.onFailure(any())
         }
 
         verify {
@@ -253,7 +253,7 @@ internal class AuthorizerImplTest : StringSpec({
         verify(exactly = 0) {
             onSuccess(any())
             loginForm.onSuccess()
-            loginForm.onFailure()
+            loginForm.onFailure(any())
         }
 
         verify {
@@ -287,6 +287,10 @@ class MockAuthCalls(
     ): Result<AuthorizationCode> {
         calledAuthorize = true
         return authorize
+    }
+
+    override fun authorizeForm(authorizeForm: AuthorizeForm): Result<AuthorizationCode> {
+        TODO("Not yet implemented")
     }
 
     override fun loginForm(
@@ -327,12 +331,12 @@ private class TestLoginFormController(
         loginFormListener?.let { attachFormListener(it) }
     }
 
-    override fun activateForm() {
+    override fun activateForm(dueTo: Throwable?) {
         if (!submitted) {
             submitted = true
             this.submit(email, password)
         } else {
-            this.giveUp()
+            this.giveUp(dueTo)
         }
     }
 }


### PR DESCRIPTION
- fixed issue when a confirmation form for authorize might be needed.
- added causes for callbacks in case of failure and give up
- added dueTo to activationForm
- fixed bug where token was not saved into storage

closes #48