### PR TITLE
#72 Abstract ApiCall#execute transformer.

### DIFF
--- a/src/main/kotlin/pcf/crskdev/koonsplash/api/ApiMeta.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/api/ApiMeta.kt
@@ -61,7 +61,7 @@ class ApiMeta internal constructor(
 class Pagination(
     val total: Int,
     val currentNumber: Int,
-    val firstPage: Link.Api,
+    val firstPage: Link.Api?,
     val prevPage: Link.Api?,
     val nextPage: Link.Api?,
     val lastPage: Link.Api?
@@ -102,10 +102,10 @@ class Pagination(
                 ?: links["prev"]?.let(page)?.inc()
                 ?: 1
             val currentPageNo = links["prev"]?.let(page)?.inc()
+                ?: links["next"]?.let(page)?.dec()
                 ?: links["first"]?.let(page)
                 ?: 1
             val firstPage = links["first"]?.let { Link.Api(it, apiCall) }
-                ?: throw IllegalStateException("First page in pagination header not found")
             val prevPage = links["prev"]?.let { Link.Api(it, apiCall) }
             val nextPage = links["next"]?.let { Link.Api(it, apiCall) }
             val lastPage = links["last"]?.let { Link.Api(it, apiCall) }

--- a/src/test/kotlin/pcf/crskdev/koonsplash/api/PaginationTest.kt
+++ b/src/test/kotlin/pcf/crskdev/koonsplash/api/PaginationTest.kt
@@ -26,6 +26,16 @@ import io.kotest.matchers.shouldBe
 import io.mockk.mockk
 
 internal class PaginationTest : StringSpec({
+    "should parse link header when on first page" {
+        val link = "<https://api.unsplash.com/photos?page=20182>; rel=\"last\", <https://api.unsplash.com/photos?page=2>; rel=\"next\""
+        val pagination = Pagination.createPagination({ mockk() }, link)
+        pagination.currentNumber shouldBe 1
+        pagination.total shouldBe 20182
+        pagination.firstPage shouldBe null
+        pagination.prevPage shouldBe null
+        pagination.nextPage?.toString() shouldBe "https://api.unsplash.com/photos?page=2"
+        pagination.lastPage?.toString() shouldBe "https://api.unsplash.com/photos?page=20182"
+    }
 
     "should fully parse link header with all page links for page 2" {
         val link =
@@ -47,7 +57,7 @@ internal class PaginationTest : StringSpec({
         pagination.total shouldBe 20149
         pagination.firstPage.toString() shouldBe "https://api.unsplash.com/photos?page=1"
         pagination.prevPage?.toString() shouldBe "https://api.unsplash.com/photos?page=20148"
-        pagination.nextPage?.toString() shouldBe null
-        pagination.lastPage?.toString() shouldBe null
+        pagination.nextPage shouldBe null
+        pagination.lastPage shouldBe null
     }
 })


### PR DESCRIPTION
- Link.Download is not coupled with OkHttp/Okio anymore.
- fixed use case for first page in pagination header.

closes #72