### PR TITLE
#144 Moved the ApiCal.cancel ext to be part of ApiCall.invoke API.

### DIFF
--- a/src/main/kotlin/pcf/crskdev/koonsplash/api/ApiDefs.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/api/ApiDefs.kt
@@ -21,8 +21,18 @@
 
 package pcf.crskdev.koonsplash.api
 
+import kotlinx.coroutines.flow.SharedFlow
+
 internal typealias FormEntry = Pair<String, String>
+/**
+ * Type alias for a api endpoint call param. Should be String, Boolean or Integer
+ */
 typealias Param = Any
+
+/**
+ * [SharedFlow] of Unit that cancels the [ApiCall] when emits.
+ */
+typealias CancelSignal = SharedFlow<Unit>
 
 /**
  * Selector for a json response [ApiJsonResponse.ApiJson]. Should be String or Int.

--- a/src/test/kotlin/pcf/crskdev/koonsplash/api/ApiCallITest.kt
+++ b/src/test/kotlin/pcf/crskdev/koonsplash/api/ApiCallITest.kt
@@ -26,6 +26,7 @@ import io.kotest.matchers.shouldBe
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import okhttp3.MediaType.Companion.toMediaType
@@ -140,15 +141,16 @@ internal class ApiCallITest : StringSpecIT({
             }
         }
 
+        val cancelSignal = MutableSharedFlow<Unit>()
         val apiCall = api.call("/photos/random/{test}?page={number}")
-        val job = launch {
+        launch {
             shouldThrowAny {
-                apiCall("test", 1)
+                apiCall("test", 1, cancel = cancelSignal)
             }
         }
         launch {
             delay(500)
-            job.cancel("manual cancel", null)
+            cancelSignal.emit(Unit)
         }.join()
     }
 

--- a/src/test/kotlin/pcf/crskdev/koonsplash/api/ApiCallITest.kt
+++ b/src/test/kotlin/pcf/crskdev/koonsplash/api/ApiCallITest.kt
@@ -74,7 +74,7 @@ internal class ApiCallITest : StringSpecIT({
             }
         }
         val apiCall = api.call("/photos/random/{test}?page={number}")
-        val response = apiCall.invoke("test", 1)
+        val response = apiCall.invoke("test", 1, cancel = null)
 
         response["id"]<String>() shouldBe "fgc48MAG3Tk"
     }

--- a/src/test/kotlin/pcf/crskdev/koonsplash/api/ApiCallTest.kt
+++ b/src/test/kotlin/pcf/crskdev/koonsplash/api/ApiCallTest.kt
@@ -21,12 +21,8 @@
 
 package pcf.crskdev.koonsplash.api
 
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.nulls.shouldBeNull
-import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -42,49 +38,6 @@ import java.io.StringReader
 
 @ExperimentalCoroutinesApi
 internal class ApiCallTest : StringSpec({
-
-    "should cancel request" {
-        val call = mockk<ApiCall>()
-        coEvery { call.invoke(any()) } coAnswers {
-            delay(1000)
-            ApiJsonResponse(mockk(), StringReader("[]"), emptyMap())
-        }
-        launch {
-            val cancelSignal = MutableSharedFlow<Unit>()
-            launch {
-                delay(300)
-                cancelSignal.emit(Unit)
-            }
-            val result = call.cancelable(cancelSignal, this)
-            result.shouldBeNull()
-            cancelSignal.subscriptionCount.value shouldBe 0
-            this.cancel()
-        }
-    }
-
-    "should not cancel request" {
-        val call = mockk<ApiCall>()
-        coEvery { call.invoke(any()) } coAnswers {
-            ApiJsonResponse(mockk(), StringReader("[]"), emptyMap())
-        }
-        launch {
-            val cancelSignal = MutableSharedFlow<Unit>()
-            val result = call.cancelable(cancelSignal)
-            result.shouldNotBeNull()
-            cancelSignal.subscriptionCount.value shouldBe 0
-            this.cancel()
-        }
-    }
-
-    "should throw if something goes wrong with request" {
-        val call = mockk<ApiCall>()
-        coEvery { call.invoke(any()) } coAnswers {
-            throw IllegalStateException()
-        }
-        shouldThrow<IllegalStateException> {
-            call.cancelable(MutableSharedFlow(), this)
-        }
-    }
 
     "should cancel execute manually" {
         val call = mockk<ApiCall>()


### PR DESCRIPTION
closes #144 