### PR TITLE
#145 Rename AuthApi/Api#call() to endpoint()

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ runBlocking {
                 }
                 .build()
                 .authenticated(
-                    Koonsplash.AuthenticatedBuilder(charArrayOf('s','e','c','r','e','t','-','k','e','y'))
+                    Koonsplash.AuthenticatedBuilder("secret-key".toCharArray())
                         .scopes(AuthScope.PUBLIC + AuthScope.READ_USER + AuthScope.WRITE_USER)
                 )   
                 .api
-    val me = api.call("/me")()
+    val me = api.endpoint("/me").call()
     val myLikesLink: Link.Api = me["links"]["likes"]()
     val firstLikedPhoto = myLikesLink.call()[0]
     val link: Link.Download = firstLikedPhoto["links"]["download_location"]()

--- a/src/main/kotlin/pcf/crskdev/koonsplash/Main.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/Main.kt
@@ -49,7 +49,7 @@ fun main() {
             )
             .api
 
-        val me = api.call("/me")()
+        val me = api.endpoint("/me")()
         val myLikesLink: Link.Api = me["links"]["likes"]()
         val firstLikedPhoto = myLikesLink.call()[0]
         val id: String = firstLikedPhoto["id"]()

--- a/src/main/kotlin/pcf/crskdev/koonsplash/api/Api.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/api/Api.kt
@@ -62,7 +62,7 @@ interface Api {
      * @param verb Http verb, default [Verb.Get]
      * @return ApiCall than can be called with Params if wildcard is present
      */
-    fun call(endpoint: String, verb: Verb = Verb.Get): ApiCall
+    fun endpoint(endpoint: String, verb: Verb = Verb.Get): ApiCall
 }
 
 /**
@@ -76,7 +76,7 @@ internal class ApiImpl(
     private val koonsplashContext: KoonsplashContext,
 ) : Api {
 
-    override fun call(endpoint: String, verb: Verb): ApiCall =
+    override fun endpoint(endpoint: String, verb: Verb): ApiCall =
         ApiCallImpl(
             Endpoint(HttpClient.apiBaseUrl.toString(), endpoint, verb),
             this.httpClient,

--- a/src/main/kotlin/pcf/crskdev/koonsplash/api/ApiAuth.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/api/ApiAuth.kt
@@ -50,9 +50,9 @@ internal class ApiAuthImpl(
     private val koonsplashContext: KoonsplashContext
 ) : ApiAuth, Api by api {
 
-    override suspend fun me(verb: Verb) = call("/me", verb)()
+    override suspend fun me(verb: Verb) = endpoint("/me", verb)()
 
-    override fun call(endpoint: String, verb: Verb): ApiCall =
+    override fun endpoint(endpoint: String, verb: Verb): ApiCall =
         ApiCallImpl(
             Endpoint(HttpClient.apiBaseUrl.toString(), endpoint, verb),
             this.httpClient,

--- a/src/main/kotlin/pcf/crskdev/koonsplash/api/ApiCall.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/api/ApiCall.kt
@@ -53,7 +53,7 @@ import kotlin.math.roundToInt
 /**
  * API call.
  *
- * @see Api.call
+ * @see Api.endpoint
  *
  */
 interface ApiCall {
@@ -66,6 +66,18 @@ interface ApiCall {
      * @return [ApiJsonResponse]
      */
     suspend operator fun invoke(vararg params: Param, cancel: CancelSignal? = null): ApiJsonResponse
+
+    /**
+     * The actual call. Can be canceled.
+     *
+     * See also: [ApiCall.invoke]
+     *
+     * @param cancel Signal that cancel the call. Default null meaning that there is no cancellation.
+     * @param params Params
+     * @return [ApiJsonResponse]
+     */
+    suspend fun call(vararg params: Param, cancel: CancelSignal? = null): ApiJsonResponse =
+        this.invoke(*params, cancel = cancel)
 
     /**
      * Generic execution with observing the call progress. Can be canceled.

--- a/src/main/kotlin/pcf/crskdev/koonsplash/api/ApiDefs.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/api/ApiDefs.kt
@@ -30,9 +30,9 @@ internal typealias FormEntry = Pair<String, String>
 typealias Param = Any
 
 /**
- * [SharedFlow] of Unit that cancels the [ApiCall] when emits.
+ * [SharedFlow] of Any that cancels the [ApiCall] when emits.
  */
-typealias CancelSignal = SharedFlow<Unit>
+typealias CancelSignal = SharedFlow<*>
 
 /**
  * Selector for a json response [ApiJsonResponse.ApiJson]. Should be String or Int.

--- a/src/test/kotlin/pcf/crskdev/koonsplash/api/ApiCallTest.kt
+++ b/src/test/kotlin/pcf/crskdev/koonsplash/api/ApiCallTest.kt
@@ -73,8 +73,8 @@ internal class ApiCallTest : StringSpec({
                 )
             }
 
-            val apiCall = api.call("/photos/random/{test}?page={number}")
-            val response = apiCall.invoke("test", 1, cancel = null)
+            val apiCall = api.endpoint("/photos/random/{test}?page={number}")
+            val response = apiCall.call("test", 1, cancel = null)
 
             response["id"]<String>() shouldBe "fgc48MAG3Tk"
         }
@@ -92,7 +92,7 @@ internal class ApiCallTest : StringSpec({
                 )
             }
 
-            val apiCall = api.call("/photos/random/{test}?page={number}")
+            val apiCall = api.endpoint("/photos/random/{test}?page={number}")
             val statuses = apiCall
                 .execute(listOf("test", 1), progressType = ApiCall.Progress.Raw)
                 .toList()
@@ -117,7 +117,7 @@ internal class ApiCallTest : StringSpec({
                 )
             }
 
-            val apiCall = api.call("/photos/random/{test}?page={number}")
+            val apiCall = api.endpoint("/photos/random/{test}?page={number}")
             val statuses = apiCall
                 .execute(listOf("test", 1), progressType = ApiCall.Progress.Percent)
                 .toList()
@@ -140,7 +140,7 @@ internal class ApiCallTest : StringSpec({
             }
 
             val cancelSignal = MutableSharedFlow<Unit>()
-            val apiCall = api.call("/photos/random/{test}?page={number}")
+            val apiCall = api.endpoint("/photos/random/{test}?page={number}")
             launch {
                 // TODO somehow this test fails on CI -> throwing a ConnectException instead.
 //                shouldThrow<CancellationException> {
@@ -170,7 +170,7 @@ internal class ApiCallTest : StringSpec({
                 )
             }
             val cancelSignal = MutableSharedFlow<Unit>()
-            val apiCall = api.call("/photos/random/{test}?page={number}")
+            val apiCall = api.endpoint("/photos/random/{test}?page={number}")
             launch {
                 apiCall.execute(listOf("test", 1), cancel = cancelSignal, progressType = ApiCall.Progress.Percent)
                     .toList()[1].shouldBeInstanceOf<ApiCall.Status.Canceled<ApiJsonResponse>>()


### PR DESCRIPTION
closes #145 