### PR TITLE
#156 Rename ApiCall#execute to callWithProgress()

### DIFF
--- a/src/main/kotlin/pcf/crskdev/koonsplash/api/EndpointParser.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/api/EndpointParser.kt
@@ -57,7 +57,7 @@ internal class EndpointParser(endpoint: Endpoint) {
      * @param params Params
      * @return list of endpoint tokens.
      */
-    fun parse(vararg params: Any): List<Token> {
+    fun parse(vararg params: Param): List<Token> {
         if (baseUrl == path) { // we have full url, need for parsing
             return emptyList()
         }

--- a/src/main/kotlin/pcf/crskdev/koonsplash/api/Link.kt
+++ b/src/main/kotlin/pcf/crskdev/koonsplash/api/Link.kt
@@ -167,12 +167,12 @@ sealed class Link(val url: URI, internal val context: KoonsplashContext) {
             return when (policy) {
                 Policy.UNSPLASH ->
                     this.context.apiCaller(url.toString())
-                        .execute(emptyList(), progressType = ApiCall.Progress.Ignore)
+                        .callWithProgress(progressType = ApiCall.Progress.Ignore)
                         .flatMapConcat {
                             when (it) {
                                 is ApiCall.Status.Done -> {
                                     val downloadUrl: String = it.resource["url"]()
-                                    this.context.apiCaller(downloadUrl).execute(emptyList(), progressType) { response ->
+                                    this.context.apiCaller(downloadUrl).callWithProgress(progressType) { response ->
                                         save(response, dir, fileName, bufferSize)
                                     }
                                 }
@@ -182,7 +182,7 @@ sealed class Link(val url: URI, internal val context: KoonsplashContext) {
                         }
                         .flowOn(dispatcher)
                 Policy.IMGIX ->
-                    this.context.apiCaller(this.url.toString()).execute(emptyList(), progressType) { response ->
+                    this.context.apiCaller(this.url.toString()).callWithProgress(progressType) { response ->
                         save(response, dir, fileName, bufferSize)
                     }.flowOn(dispatcher)
             }

--- a/src/test/kotlin/pcf/crskdev/koonsplash/api/ApiCallTest.kt
+++ b/src/test/kotlin/pcf/crskdev/koonsplash/api/ApiCallTest.kt
@@ -94,7 +94,7 @@ internal class ApiCallTest : StringSpec({
 
             val apiCall = api.endpoint("/photos/random/{test}?page={number}")
             val statuses = apiCall
-                .execute(listOf("test", 1), progressType = ApiCall.Progress.Raw)
+                .callWithProgress("test", 1, progressType = ApiCall.Progress.Raw)
                 .toList()
 
             statuses.filterIsInstance<ApiCall.Status.Current<*>>()
@@ -119,7 +119,7 @@ internal class ApiCallTest : StringSpec({
 
             val apiCall = api.endpoint("/photos/random/{test}?page={number}")
             val statuses = apiCall
-                .execute(listOf("test", 1), progressType = ApiCall.Progress.Percent)
+                .callWithProgress("test", 1, progressType = ApiCall.Progress.Percent)
                 .toList()
 
             statuses.filterIsInstance<ApiCall.Status.Current<*>>()
@@ -172,7 +172,7 @@ internal class ApiCallTest : StringSpec({
             val cancelSignal = MutableSharedFlow<Unit>()
             val apiCall = api.endpoint("/photos/random/{test}?page={number}")
             launch {
-                apiCall.execute(listOf("test", 1), cancel = cancelSignal, progressType = ApiCall.Progress.Percent)
+                apiCall.callWithProgress("test", 1, cancel = cancelSignal, progressType = ApiCall.Progress.Percent)
                     .toList()[1].shouldBeInstanceOf<ApiCall.Status.Canceled<ApiJsonResponse>>()
             }
             launch {

--- a/src/test/kotlin/pcf/crskdev/koonsplash/api/EndpointParserTest.kt
+++ b/src/test/kotlin/pcf/crskdev/koonsplash/api/EndpointParserTest.kt
@@ -53,12 +53,15 @@ internal class EndpointParserTest : StringSpec({
     }
 
     "should parse with wildcard params" {
-        EndpointParser(
-            Endpoint(
-                api,
-                "$api/photos/{id}/collection/{collection_id}?page={page}&q={q}&fm={jpg}&ordered={ordered}"
-            )
-        ).parse("12345", "col23", 1, 75, "jpg", true) shouldBe listOf(
+        fun parse(vararg params: Param) =
+            EndpointParser(
+                Endpoint(
+                    api,
+                    "$api/photos/{id}/collection/{collection_id}?page={page}&q={q}&fm={jpg}&ordered={ordered}"
+                )
+            ).parse(*params)
+
+        parse("12345", "col23", 1, 75, "jpg", true) shouldBe listOf(
             EndpointParser.Token.Path("photos"),
             EndpointParser.Token.Path("12345"),
             EndpointParser.Token.Path("collection"),


### PR DESCRIPTION
Renamed `ApiCall#execute()`  and its overloads to `ApiCall#callWithProgress()`

closes #156